### PR TITLE
Replace GitHub emoji shortcodes with unicode emoji

### DIFF
--- a/docx-asciidoc-conversion/attributes.adoc
+++ b/docx-asciidoc-conversion/attributes.adoc
@@ -1,10 +1,10 @@
 // Admonition icons:
 // TG Requirement
-:important-caption: :closed_book:
+:important-caption: 📕
 // TG Recommendation
-:tip-caption: :ledger:
+:tip-caption: 📒
 // Conformance class
-:note-caption: :blue_book:
+:note-caption: 📘
 
 // TOC placement using macro (manual)
 :toc: macro

--- a/metadata/metadata-iso19139/metadata-iso19139.adoc
+++ b/metadata/metadata-iso19139/metadata-iso19139.adoc
@@ -1,6 +1,6 @@
-:important-caption: :closed_book:
-:tip-caption: :ledger:
-:note-caption: :blue_book:
+:important-caption: 📕
+:tip-caption: 📒
+:note-caption: 📘
 :toc: macro
 :toc-title:
 :toclevels: 4


### PR DESCRIPTION
The GitHub emoji shortcodes only work when the Asciidoc is rendered on GitHub.

![image](https://user-images.githubusercontent.com/11427611/145638975-71528464-fcb1-4215-878f-6a66e6d61f6c.png)

When converting the .adoc file to HTML using asciidoctor before this commit, the following was shown:

![image](https://user-images.githubusercontent.com/11427611/145638952-8e740a4d-a1d9-4aa9-8517-34e70df9539f.png)
