### PR TITLE
rename codelist URL ...QualityOfServiceCriteriaCode -> ...QualityOfServiceCriteria

### DIFF
--- a/metadata/metadata-iso19139/metadata-iso19139.adoc
+++ b/metadata/metadata-iso19139/metadata-iso19139.adoc
@@ -4277,7 +4277,7 @@ In Table 1 of [Regulation 1312/2014], Annex II, Part C, the multiplicity for the
 
 The minimum values for each of the Quality of Service criteria given in Table 6.1 shall be given in the metadata. They shall be encoded using one _gmd:report/gmd:DQ_ConceptualConsistency_ element within the _gmd:DQ_DataQuality_ element scoped for the entire service.
 
-The value of _gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure_ shall be shall be an _gmx:Anchor_ element referring to the code list value for the criterion in the INSPIRE Registryfootnote:[Attribute xlink:href with URL value starting with "http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/" and postfixed with one of values of code list QualityOfServiceCriteriaCode, see Annex D.4] and expressing the name of the criterion in the language of the metadata.
+The value of _gmd:DQ_ConceptualConsistency/gmd:nameOfMeasure_ shall be shall be an _gmx:Anchor_ element referring to the code list value for the criterion in the INSPIRE Registryfootnote:[Attribute xlink:href with URL value starting with "http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/" and postfixed with one of values of code list QualityOfServiceCriteria, see Annex D.4] and expressing the name of the criterion in the language of the metadata.
 
 The description of the measurement of the criterion shall be encoded using the _gmd:DQ_ConceptualConsistency/gmd:measureDescription_ element.
 
@@ -4293,15 +4293,15 @@ The purpose of these quality of service metadata elements is to describe the min
 [width="100%",cols="24%,26%,50%"]
 |===
 .4+|Minimum availability |Definition |Lower limit of the percentage of time the service is estimated to be available on a yearly basis.
-|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/availability
+|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/availability
 |Value type |xsi:double between 0..100
 |Unit of measure |urn:ogc:def:uom:OGC::percent
 .4+|Minimum performance |Definition |The maximum response time within which a typical request to the Spatial Data Service can be carried out in a normal situation, by returning at least the initial part of the response. The normal situation represents periods out of peak load. It is set at 90% of the time.
-|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/performance
+|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/performance
 |Value type |xsi:double
 |Unit of measure |http://www.opengis.net/def/uom/SI/second
 .4+|Minimum capacity |Definition |Lower limit of the maximum number of simultaneous requests that can be completed within the limits of the declared performance.
-|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/capacity
+|Identifier URI |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/capacity
 |Value type |xsi:integer
 |Unit of measure |http://www.opengis.net/def/uom/OGC/1.0/unity
 |===
@@ -4313,7 +4313,7 @@ The purpose of these quality of service metadata elements is to describe the min
 <gmd:report>
   <gmd:DQ_ConceptualConsistency>
     <gmd:nameOfMeasure>
-      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/performance">performance
+      <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/performance">performance
       </gmx:Anchor>
     </gmd:nameOfMeasure>
     <gmd:measureDescription>
@@ -6095,7 +6095,7 @@ Capacity (capacity)
 |INSPIRE obligation / condition |Mandatory for interoperable spatial data services
 |INSPIRE multiplicity |[1] For each criteria
 |Data type (and ISO 19115 no.) |MD_Identifier/code
-|Domain |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/availability
+|Domain |http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/availability
 |Example |INSPIRE QoS2
 |Comments |
 |===


### PR DESCRIPTION
Rename codelist URL's:

- from: http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteriaCode/*
- to: http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/*

Fixes #77.

---

Changes only applied to the metadata-iso19139.adoc source file. Based on the repo documentation I could not figure out how to generate the pdf and html output based on the adoc source file. So these files have not been updated. Considering the `pdf` and `html` output are derivative products of the `adoc` source files it would make more sense to not include the `html` and `pdf` files in the source repository - and instead include them on the gh-pages branch (auto-generated). 

