### PR TITLE
Replace (C) with \(C) to prevent it from being rendered as ©

### DIFF
--- a/services/download-atom-wfs/DownloadServices.adoc
+++ b/services/download-atom-wfs/DownloadServices.adoc
@@ -1174,21 +1174,21 @@ a|
 |Resource Title (M) |/feed/title
 |Resource Abstract (M) |/feed/subtitle
 |Resource Type (M) |Not mapped
-|Resource Locator (C) a|
+|Resource Locator \(C) a|
 Feed level link in the top Atom feed
 
 /feed/link[@rel="self"]
 
-|Coupled Resource (C) a|
+|Coupled Resource \(C) a|
 Entry level link in the top Atom feed
 
 /feed/entry/link[@rel="describedby"]
 
 |Spatial Data Service Type (M) |Not mapped
 |Keyword (M) |Not mapped
-|Geographic Bounding Box (C) |Not mapped
+|Geographic Bounding Box \(C) |Not mapped
 |Temporal Reference (M) |Not mapped
-|Spatial Resolution (C) |Not mapped
+|Spatial Resolution \(C) |Not mapped
 |Conformity (M) |Not mapped
 |Conditions for Access and Use (M) |Not mapped
 |Limitations on Public Access (M) a|
@@ -2335,12 +2335,12 @@ inspire_common:ResourceType
 
 (ExtendedCapabilities)
 
-|Resource Locator (C) a|
+|Resource Locator \(C) a|
 inspire_common:ResourceLocator
 
 (ExtendedCapabilities)
 
-|Coupled Resource (C) |wfs:MetadataURL (per feature type)
+|Coupled Resource \(C) |wfs:MetadataURL (per feature type)
 |Spatial Data Service Type (M) a|
 inspire_common:SpatialDataServiceType
 
@@ -2353,7 +2353,7 @@ inspire_common:TemporalReference
 
 (ExtendedCapabilities)
 
-|Spatial Resolution (C) |ows:ServiceIdentification/ows:Abstract
+|Spatial Resolution \(C) |ows:ServiceIdentification/ows:Abstract
 a|
 Conformity* (M)
 


### PR DESCRIPTION
Fix for the copyright symbol in the TG Download.

![image](https://github.com/INSPIRE-MIF/technical-guidelines/assets/11427611/2adf46e4-cb1d-48e4-93aa-49e765206c69)

See also https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/ and https://docs.asciidoctor.org/asciidoc/latest/subs/prevent/