### PR TITLE
Replace wrong value "codeList" with "codelist"

### DIFF
--- a/data/ef/dataspecification_ef.adoc
+++ b/data/ef/dataspecification_ef.adoc
@@ -5132,7 +5132,7 @@ a|
 !Name: !measurement regime
 !Definition: !Categories for different types of the MeasurementRegime.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/MeasurementRegimeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/MeasurementRegimeValue
 !Values: !
 !===
 
@@ -5190,7 +5190,7 @@ a|
 !Name: !media
 !Definition: !Categories for different types of media.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/MediaValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/MediaValue
 !Values: !
 !===
 
@@ -5268,7 +5268,7 @@ a|
 !Name: !process type
 !Definition: !Categories for different process types.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/ProcessTypeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ProcessTypeValue
 !Values: !
 !===
 
@@ -5308,7 +5308,7 @@ a|
 !Name: !result acquisition source
 !Definition: !Categories for different types of the ResultAcquisitionSource.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/ResultAcquisitionSourceValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ResultAcquisitionSourceValue
 !Values: !
 !===
 
@@ -5366,7 +5366,7 @@ a|
 !Name: !result nature
 !Definition: !State of the result of an observation.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/ResultNatureValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ResultNatureValue
 !Values: !
 !===
 

--- a/data/el/dataspecification_el.adoc
+++ b/data/el/dataspecification_el.adoc
@@ -2532,18 +2532,18 @@ The externally governed code lists included in this application schema are speci
 [cols=",,,",options="header",]
 |===
 |*Code list* |*Identifiers* |*Identifier examples* |*Labels*
-.11+|SpotElevationClassValue .11+|Append the number in the "Classification Value" column of Table 4.9 to the URI prefix _http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/0_ |_Created, never classified_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/1_ |_Unclassified_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/2_ |_Ground_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/3_ |_Low Vegetation_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/4_ |_Medium Vegetation_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/5_ |_High Vegetation_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/6_ |_Building_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/7_ |_Low point (noise)_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/8_ |_Model Key-point (mass point)_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/9_ |_Water_
-|_http://inspire.ec.europa.eu/codeList/SpotElevationClassValue/12_ |_Overlap Points_
+.11+|SpotElevationClassValue .11+|Append the number in the "Classification Value" column of Table 4.9 to the URI prefix _http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/0_ |_Created, never classified_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/1_ |_Unclassified_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/2_ |_Ground_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/3_ |_Low Vegetation_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/4_ |_Medium Vegetation_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/5_ |_High Vegetation_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/6_ |_Building_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/7_ |_Low point (noise)_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/8_ |_Model Key-point (mass point)_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/9_ |_Water_
+|_http://inspire.ec.europa.eu/codelist/SpotElevationClassValue/12_ |_Overlap Points_
 |===
 
 <<<

--- a/data/ge/dataspecification_ge.adoc
+++ b/data/ge/dataspecification_ge.adoc
@@ -19654,7 +19654,7 @@ Observations always focus on some property of the feature of interest. It is eit
 
 [source, xml]
 <omop:ObservableProperty gml:id="op1">
-   <omop:basePhenomenon codeSpace="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/magneticProperty">MAG_T</omop:basePhenomenon>
+   <omop:basePhenomenon codeSpace="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/magneticProperty">MAG_T</omop:basePhenomenon>
    <omop:uom uom="nT"/>
   <omop:statisticalMeasure>
       <omop:StatisticalMeasure gml:id="sm1">
@@ -19689,17 +19689,17 @@ GeophResult
       resource
          linkage ”http://any.institution/getItem?id=asd-123.1.1.segy”
          description ”SEG-Y field data line-1.1”
-      resourceType "http://inspire.ec.europa.eu/codeList/ResourceTypeValue/seismicResource/SEG-Y "
+      resourceType "http://inspire.ec.europa.eu/codelist/ResourceTypeValue/seismicResource/SEG-Y "
    geophResource
       resource
          linkage ”http://any.institution/getItem?id=asd-123.1.2.segy”
          description ”SEG-Y field data line-1.2”
-      resourceType " http://inspire.ec.europa.eu/codeList/ResourceTypeValue/seismicResource/SEG-Y "
+      resourceType " http://inspire.ec.europa.eu/codelist/ResourceTypeValue/seismicResource/SEG-Y "
    geophResource
       resource
          linkage ”http://any.institution/getItem?id=asd-123.1.3.segy”
          description ”SEG-Y field data line-1.3”
-      resourceType " http://inspire.ec.europa.eu/codeList/ResourceTypeValue/seismicResource/SEG-Y "
+      resourceType " http://inspire.ec.europa.eu/codelist/ResourceTypeValue/seismicResource/SEG-Y "
 
 [discrete]
 ===== Dividing data sets
@@ -19803,12 +19803,12 @@ It seems to be reasonable not to use different encoding on the basis of the numb
    <gmlcov:rangeType>
       <swe:DataRecord>
          <swe:field name="observedGravity">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/observedGravity">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/observedGravity">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="errorOfClosure">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/errorOfClosure">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/errorOfClosure">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
@@ -19870,27 +19870,27 @@ stn-005 980000 980000 980000 0 0</gml:tupleList>
             </swe:Text>
          </swe:field>
          <swe:field name="observedGravity">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/observedGravity">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/observedGravity">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="gravityFreeAirAnomaly">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/gravityFreeAirAnomaly">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/gravityFreeAirAnomaly">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="gravityBouguerAirAnomaly">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/gravityBouguerAnomaly">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/gravityBouguerAnomaly">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="innerTopoCorrection">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophProcessParameterNameValue/gravityProcessParameter/topoCorrection/innerTopoCorrection">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophProcessParameterNameValue/gravityProcessParameter/topoCorrection/innerTopoCorrection">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="totalTopoCorrection">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophProcessParameterNameValue/gravityProcessParameter/topoCorrection/totalTopoCorrection">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophProcessParameterNameValue/gravityProcessParameter/topoCorrection/totalTopoCorrection">
                <swe:uom code="microGal"/>
             </swe:Quantity>
          </swe:field>
@@ -19938,12 +19938,12 @@ Layer model is a generic concept for representing a 1D structure. An efficient w
    <gmlcov:rangeType>
       <swe:DataRecord>
          <swe:field name="resistivity">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/electromagneticProperty/resistivity">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/electromagneticProperty/resistivity">
                <swe:uom code="ohmm"/>
             </swe:Quantity>
          </swe:field>
          <swe:field name="chargeability">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/electromagneticProperty/chargeability">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/electromagneticProperty/chargeability">
                <swe:uom code="ohmm"/>
             </swe:Quantity>
          </swe:field>
@@ -19994,7 +19994,7 @@ NOTE Referenceable grids can be used for nodes with uneven spacing or to project
    <gmlcov:rangeType>
       <swe:DataRecord id="drec-1">
          <swe:field name="resistivity">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/electromagneticProperty/resistivity">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/electromagneticProperty/resistivity">
                <swe:uom code="mV"/>
             </swe:Quantity>
          </swe:field>
@@ -20033,7 +20033,7 @@ The following example shows a Bouguer anomaly map encoded as RectifiedGridCovera
    <gmlcov:rangeType>
       <swe:DataRecord>
          <swe:field name=" gravityBouguerAnomaly ">
-            <swe:Quantity definition="http://inspire.ec.europa.eu/codeList/GeophPropertyNameValue/gravimetricProperty/gravityBouguerAnomaly">
+            <swe:Quantity definition="http://inspire.ec.europa.eu/codelist/GeophPropertyNameValue/gravimetricProperty/gravityBouguerAnomaly">
                <swe:uom code="ohmm"/>
             </swe:Quantity>
          </swe:field>

--- a/data/hy/dataspecification_hy.adoc
+++ b/data/hy/dataspecification_hy.adoc
@@ -756,7 +756,7 @@ The following two types of code lists are distinguished in INSPIRE:
 * _Code lists that are governed by INSPIRE (INSPIRE-governed code lists)._ These code lists will be managed centrally in the INSPIRE code list register. Change requests to these code lists (e.g. to add, deprecate or supersede values) are processed and decided upon using the INSPIRE code list register's maintenance workflows.
 
 
-INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codeList/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codeList/<CodeListName__>/<value>.
+INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codelist/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codelist/<CodeListName__>/<value>.
 
 
 * _Code lists that are governed by an organisation outside of INSPIRE (externally governed code lists)._ These code lists are managed by an organisation outside of INSPIRE, e.g. the World Meteorological Organization (WMO) or the World Health Organization (WHO). Change requests to these code lists follow the maintenance workflows defined by the maintaining organisations. Note that in some cases, no such workflows may be formally defined.
@@ -790,7 +790,7 @@ NOTE Where practicable, the INSPIRE code list register could also provide http U
 
 ===== Vocabulary
 
-For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codeList/<UpperCamelCaseName>_.
+For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codelist/<UpperCamelCaseName>_.
 
 If the value is missing or empty, this indicates an empty code list. If no sub-classes are defined for this empty code list, this means that any code list may be used that meets the given definition.
 

--- a/data/ps/dataspecification_ps.adoc
+++ b/data/ps/dataspecification_ps.adoc
@@ -764,7 +764,7 @@ The following two types of code lists are distinguished in INSPIRE:
 
 * _Code lists that are governed by INSPIRE (INSPIRE-governed code lists)._ These code lists will be managed centrally in the INSPIRE code list register. Change requests to these code lists (e.g. to add, deprecate or supersede values) are processed and decided upon using the INSPIRE code list register's maintenance workflows.
 +
-INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codeList/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codeList/<CodeListName__>/<value>.
+INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codelist/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codelist/<CodeListName__>/<value>.
 
 * _Code lists that are governed by an organisation outside of INSPIRE (externally governed code lists)._ These code lists are managed by an organisation outside of INSPIRE, e.g. the World Meteorological Organization (WMO) or the World Health Organization (WHO). Change requests to these code lists follow the maintenance workflows defined by the maintaining organisations. Note that in some cases, no such workflows may be formally defined.
 +
@@ -796,7 +796,7 @@ NOTE Where practicable, the INSPIRE code list register could also provide http U
 
 ===== Vocabulary
 
-For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codeList/<UpperCamelCaseName>_.
+For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codelist/<UpperCamelCaseName>_.
 
 If the value is missing or empty, this indicates an empty code list. If no sub-classes are defined for this empty code list, this means that any code list may be used that meets the given definition.
 

--- a/data/sd/dataspecification_sd.adoc
+++ b/data/sd/dataspecification_sd.adoc
@@ -1949,7 +1949,7 @@ XLS
 |===
 |*Code list* |*Identifiers* |*Examples*
 |Article17CountingUnitValue |Append the name in the Code column in the table 
-Population units to the base URI http://inspire.ec.europa.eu/codeList/ Article17CountingUnitValue/ |"i" 
+Population units to the base URI http://inspire.ec.europa.eu/codelist/ Article17CountingUnitValue/ |"i" 
 "stones"
 |PopulationTypeValue |Append the name in the TYPE heading of section '7) Other codelists (SDF fields 3.2, 3.3.)' 'TYPE: 
 p = permanent; r = reproducing; c = concentration; w = wintering; (for plant and non-migratory species use permanent)' 
@@ -2437,7 +2437,7 @@ http://bd.eionet.europa.eu/article17/reference_portal
 |===
 |*Code list* |*Identifiers* |*Examples*
 |Article17SourceMethodValue |Append the codes in the field '1.1.2 Method used-map' from page 4 of the Reporting Formats for Article17, the codes to be used are 
-3,2,1,0. Refer to the document for more detailed description. For the reporting under Article 12 of the Birds Directive the codes are the same. |http://inspire.ec.europa.eu/codeList/Article17SourceMethodValue/3
+3,2,1,0. Refer to the document for more detailed description. For the reporting under Article 12 of the Birds Directive the codes are the same. |http://inspire.ec.europa.eu/codelist/Article17SourceMethodValue/3
 |===
 
 [cols=",,",options="header",]
@@ -4968,7 +4968,7 @@ a|
 !Name: !counting method value
 !Definition: !Method for producing numbers indicating the abundance of a species within an aggregation unit.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/CountingMethodValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CountingMethodValue
 !Values: !The allowed values for this code list comprise only the values specified in the table below.
 !===
 
@@ -5015,7 +5015,7 @@ a|
 !Name: !general counting unit value
 !Definition: !The unit used to express a counted or estimated number indicating the abundance within a SpeciesAggregationUnit (e.g. ccurrences or the population size).
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/GeneralCountingUnitValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/GeneralCountingUnitValue
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -5110,7 +5110,7 @@ a|
 !Definition: !The species population density in the SpeciesDistributionUnit.
 !Description: !A species population density in classes (common, rare, very rare or present) in an individual SpeciesDistributionUnit.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/OccurrenceCategoryValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/OccurrenceCategoryValue
 !Values: !The allowed values for this code list comprise the values specified in the table below and additional values at any level defined by data providers.
 !===
 
@@ -5175,7 +5175,7 @@ a|
 !Name: !qualifier value
 !Definition: !This value defines the relation between the taxonomic concepts of a local species name and the reference species name given by reference species identifier or by a reference species scheme.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/QualifierValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/QualifierValue
 !Values: !The allowed values for this code list comprise only the values specified in the table below.
 !===
 
@@ -5241,7 +5241,7 @@ a|
 !Definition: !Reference lists defining a nomenclatural and taxonomical standard to which local names and taxonomic concepts can be mapped.
 !Description: !The authorized ReferenceSpeciesScheme provides reference species list which defines the ReferenceSpeciesName with its scientific name plus author and ReferenceSpeciesId. In these ReferenceSpeciesSchemes harmonized species names are given GUIDs and the species names are to be retrieved through webservices using GUIDs. Only one of these list must be used for one taxon. The priority is as follows: 1) EU-Nomen, 2) EUNIS, 3) NatureDirectives. This implies: if a taxon is listed in EU-Nomen, this reference must be used as first choice. If it is not listed in EU-Nomen, the second choice is EUNIS, if not in EUNIS, NatureDirectives can be used.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/ReferenceSpeciesSchemeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ReferenceSpeciesSchemeValue
 !Values: !The allowed values for this code list comprise only the values specified in the table below.
 !===
 
@@ -5291,7 +5291,7 @@ a|
  
 NOTE One or more categories of population may be listed in the dataset, giving population size of e.g. permanent and wintering populations.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/ResidencyStatusValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ResidencyStatusValue
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 

--- a/data/us/dataspecification_us.adoc
+++ b/data/us/dataspecification_us.adoc
@@ -4232,7 +4232,7 @@ a|
 !Name: !thermal appurtenance type
 !Definition: !Classification of thermal appurtenances.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/ThermalAppurtenanceTypeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ThermalAppurtenanceTypeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -9761,7 +9761,7 @@ a|
 !Name: !thermal appurtenance type value
 !Definition: !Codelist containing a classification of thermal appurtenances.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/US/ThermalAppurtenanceTypeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/US/ThermalAppurtenanceTypeValue
 !Parent: !AppurtenanceTypeValue
 !Values: !
 !===


### PR DESCRIPTION
Certain codelist identifiers contain the wrong value "codeList" instead of "codelist".
This fix applies to the following TGs: EF, EL, GE, HY, PS, SD, US.