### PR TITLE
Modify wrong link to changelog

### DIFF
--- a/data/ef/dataspecification_ef.adoc
+++ b/data/ef/dataspecification_ef.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Environmental Monitoring Facilities
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/data/el/dataspecification_el.adoc
+++ b/data/el/dataspecification_el.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Elevation
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image::./media/image2.jpeg[image,width=93,height=93,align=center]

--- a/data/gg/dataspecification_gg.adoc
+++ b/data/gg/dataspecification_gg.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Geographical Grid Systems
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/data/hy/dataspecification_hy.adoc
+++ b/data/hy/dataspecification_hy.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Hydrography
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/data/lu/dataspecification_lu.adoc
+++ b/data/lu/dataspecification_lu.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Land Us
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/data/ps/dataspecification_ps.adoc
+++ b/data/ps/dataspecification_ps.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Protected Sites
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/data/rs/dataspecification_rs.adoc
+++ b/data/rs/dataspecification_rs.adoc
@@ -31,7 +31,7 @@
 :description: This document describes the INSPIRE Data Specification for the spatial data theme Coordinate Reference Systems
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:./media/image2.jpeg[image,width=131,height=90, align=center]

--- a/metadata/metadata-iso19139/metadata-iso19139.adoc
+++ b/metadata/metadata-iso19139/metadata-iso19139.adoc
@@ -19,7 +19,7 @@
 :description: Implementation specification for defining metadata for INSPIRE datasets and services in ISO/TS 19139 based XML format in compliance with the INSPIRE Implementing Rules for metadata.
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution (cc-by) 4.0]
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: EN
 
 image:./media/image1.png[image,width=107,height=107] **INSPIRE** - *Infrastructure for Spatial Information in Europe*

--- a/services/download-atom-wfs/DownloadServices.adoc
+++ b/services/download-atom-wfs/DownloadServices.adoc
@@ -32,7 +32,7 @@
 :keywords: INSPIRE Download Services
 :author: Temporary MIWP 2021-2024 sub-group 2.3.1
 :copyright: Public
-:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/2023.1
+:revremark: https://github.com/INSPIRE-MIF/technical-guidelines/releases/tag/v2023.1
 :lang: en
 
 image:media/image1.png[image,width=107,height=107] **INSPIRE** *Infrastructure for Spatial Information in Europe*


### PR DESCRIPTION
Modify the wrong link to the changelog in the information section of all TGs released in the v2023.1 release.