### PR TITLE
Replace wrong value "codeList" with "codelist"

### DIFF
--- a/data/af/dataspecification_af.adoc
+++ b/data/af/dataspecification_af.adoc
@@ -5558,7 +5558,7 @@ a|
 !Name: !AquacultureActivityValue
 !Definition: !Type of aquaculture activity.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/AquacultureActivityValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/AquacultureActivityValue
 !Values: !
 !===
 
@@ -5617,7 +5617,7 @@ a|
 !Name: !AquacultureInstallationValue
 !Definition: !Type of aquaculture installation.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/AquacultureInstallationValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/AquacultureInstallationValue
 !Values: !
 !===
 
@@ -5712,7 +5712,7 @@ a|
 !Name: !EnvironmentValue
 !Definition: !The type of the environment in which the aquaculture organisms are kept. (a water type classification).
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/EnvironmentValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EnvironmentValue
 !Values: !
 !===
 
@@ -5765,7 +5765,7 @@ a|
 !Name: !HealthStatusValue
 !Definition: !A code list with the possible status values indicating the granted health status.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/HealthStatusValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/HealthStatusValue
 !Values: !
 !===
 
@@ -5824,7 +5824,7 @@ a|
 !Name: !InstallationPartValue
 !Definition: !Describes the type of the installation part, according to a code list.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/InstallationPartValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/InstallationPartValue
 !Values: !
 !===
 
@@ -5949,7 +5949,7 @@ a|
 !Name: !IrrigationMethodeValue
 !Definition: !List the different methods of irrigation, according to EU regulation EC 1200/2009, annex III, chapter VIII.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/IrrigationMethodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/IrrigationMethodeValue
 !Values: !
 !===
 
@@ -5999,7 +5999,7 @@ a|
 !Name: !PlotActivityValue
 !Definition: !The economic activity executed on the plot, as coded accoring to EU regulation (EC) 1200/2009, annex II, chapter 2. (codes 2.01 - 2.04.07 and 2.06.03 - 2.06.04).
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/PlotActivityValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/PlotActivityValue
 !Values: !
 !===
 
@@ -6717,7 +6717,7 @@ a|
 !Definition: !The type of building, expressed as a code.
 !Description: !animal housing according to EU regulation (EC) 1200/2009 annex III chapter V, codes 5.01 - 5.03.99.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/TypeOfAgriBuildingValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/TypeOfAgriBuildingValue
 !Values: !
 !===
 
@@ -7081,7 +7081,7 @@ a|
 !Name: !WaterSourceValue
 !Definition: !The type of water source, according to Regulation (EC) No 1200/2009.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/WaterSourceValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/WaterSourceValue
 !Values: !
 !===
 

--- a/data/hb/dataspecification_hb.adoc
+++ b/data/hb/dataspecification_hb.adoc
@@ -1464,7 +1464,7 @@ a|
 !Name: !eunis habitat type code value
 !Definition: !EUNIS habitat types classification.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/EunisHabitatTypeCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EunisHabitatTypeCodeValue
 !Values: !The allowed values for this code list comprise only the values specified in "Classification of habitat types according to the EUNIS Biodiversity database, as specified in the EUNIS habitat types classification published on the web site of the European Environment Agency" .
 !===
 
@@ -1481,7 +1481,7 @@ a|
 !Name: !habitat directive code value
 !Definition: !Habitats Directive Annex I habitats.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/HabitatsDirectiveCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/HabitatsDirectiveCodeValue
 !Values: !The allowed values for this code list comprise only the values specified in "Classification of habitat types according to Annex I to Directive 92/43/EEC" .
 !===
 
@@ -1515,7 +1515,7 @@ a|
 !Name: !marine strategy framework directive code value
 !Definition: !Marine Strategy Framework Directive.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/MarineStrategyFrameworkDirectiveCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/MarineStrategyFrameworkDirectiveCodeValue
 !Values: !The allowed values for this code list comprise only the values specified in "Classification of habitat types according to table 1 of Annex III to Directive 2008/56/EC" .
 !===
 
@@ -1532,7 +1532,7 @@ a|
 !Name: !qualifier local name value
 !Definition: !List of values that specify the relation between a locally used name and a name used at the pan-European level.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/QualifierLocalNameValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/QualifierLocalNameValue
 !Values: !The allowed values for this code list comprise only the values specified in _Annex C_ .
 !===
 
@@ -1567,7 +1567,7 @@ a|
 !Definition: !This value defines which pan-european habitat classification scheme has been used.
 !Description: !EXAMPLE Eunis
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/ReferenceHabitatTypeSchemeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ReferenceHabitatTypeSchemeValue
 !Values: !The allowed values for this code list comprise only the values specified in _Annex C_ .
 !===
 
@@ -2397,7 +2397,7 @@ a|
 !Description: !Describes how the information about the occurrences of the habitats within a a unit has been compiled. 
 NOTE The values of the list are found here: http://circa.europa.eu/Public/irc/env/monnat/library?l=/habitats_reporting/reporting_2007-2012/reporting_guidelines/reporting-formats_1/_EN_1.0_&a=d
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/Article17SourceMethodValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/Article17SourceMethodValue
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -2710,7 +2710,7 @@ The values of selected external code lists are included in Annex D for informati
 |===
 |*Code list* |*Identifiers* |*Examples*
 |Article17SourceMethodValue |Append the codes in the field '1.1.2 Method used-map' from page 4 of the Reporting Formats for Article 17 to the identifier URI. The codes to be used are 
-3,2,1,0. Refer to the document for more detailed description. For the reporting under Article 12 of the Birds Directive the codes are the same. |http://inspire.ec.europa.eu/codeList/ Article17SourceMethodValue/3
+3,2,1,0. Refer to the document for more detailed description. For the reporting under Article 12 of the Birds Directive the codes are the same. |http://inspire.ec.europa.eu/codelist/ Article17SourceMethodValue/3
 |===
 
 [cols=",,",options="header",]
@@ -7089,7 +7089,7 @@ a|
 !Name: !qualifier local name value
 !Definition: !List of values that specify the relation between a locally used name and a name used at the pan-European level.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/QualifierLocalNameValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/QualifierLocalNameValue
 !Values: !The allowed values for this code list comprise only the values specified in the table below.
 !===
 
@@ -7155,7 +7155,7 @@ a|
 !Definition: !This value defines which pan-european habitat classification scheme has been used.
 !Description: !EXAMPLE Eunis
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/ReferenceHabitatTypeSchemeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ReferenceHabitatTypeSchemeValue
 !Values: !The allowed values for this code list comprise only the values specified in the table below.
 !===
 

--- a/data/hh/dataspecification_hh.adoc
+++ b/data/hh/dataspecification_hh.adoc
@@ -712,7 +712,7 @@ NOTE Where practicable, the INSPIRE code list register could also provide http U
 
 ===== Vocabulary
 
-For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codeList/<UpperCamelCaseName>_.
+For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codelist/<UpperCamelCaseName>_.
 
 If the value is missing or empty, this indicates an empty code list. If no sub-classes are defined for this empty code list, this means that any code list may be used that meets the given definition.
 
@@ -2375,7 +2375,7 @@ a|
 !Definition: !Disease as defined in the ICD-10 update 2007 "ICD (International Classification of Diseases, 10th revision)".
 !Description: !As values in the INSPIRE data, the code could be used (e.g A00, A01, A01.1, ...).
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/ICDvalue
+!Identifier: !http://inspire.ec.europa.eu/codelist/ICDvalue
 !Values: !The allowed values for this code list comprise only the values specified in "10th Revision of the International Statistical Classification of Diseases and Related Health Problems, published by the World Health Organization" .
 !===
 
@@ -2394,7 +2394,7 @@ a|
 !Description: !COD data refer to the underlying cause which - according to the World Health Organisation (WHO) - is "the disease or injury which initiated the train of morbid events leading directly to death, or the circumstances of the accident or violence which produced the fatal injury". Causes of death are classified by the 65 causes of the "European shortlist" of causes of death. This shortlist is based on the International Statistical Classification of Diseases and Related Health Problems (ICD). 
 As values in the INSPIRE data, the numeric code could be used (e.g 01, 02, 03...).
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/CODvalue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CODvalue
 !Values: !The allowed values for this code list comprise only the values specified in "European Shortlist for Causes of Death published by Eurostat" .
 !===
 
@@ -2603,8 +2603,8 @@ The externally governed code lists included in this application schema are speci
 [cols=",,,",options="header",]
 |===
 |*Code list* |*Identifiers* |*Identifier examples* |*Labels*
-|ICDValue |Append the upper-case alphanumeric code in the "Code" column of Annex A6 to the URI prefix http://inspire.ec.europa.eu/codeList/ICDValue/ |_http://inspire.ec.europa.eu/codeList/ICDValue/A00 for Cholera_ |The name after the code in the ICD10online website; e.g Cholera
-|CODValue |Append the two numeric code in the "Code" column of Annex A6 to the URI prefix http://inspire.ec.europa.eu/codeList/CODValue/ |_http://inspire.ec.europa.eu/codeList/CODValue/29_ |The name after the code in the COD website; e.g Alcohol abuse
+|ICDValue |Append the upper-case alphanumeric code in the "Code" column of Annex A6 to the URI prefix http://inspire.ec.europa.eu/codelist/ICDValue/ |_http://inspire.ec.europa.eu/codelist/ICDValue/A00 for Cholera_ |The name after the code in the ICD10online website; e.g Cholera
+|CODValue |Append the two numeric code in the "Code" column of Annex A6 to the URI prefix http://inspire.ec.europa.eu/codelist/CODValue/ |_http://inspire.ec.europa.eu/codelist/CODValue/29_ |The name after the code in the COD website; e.g Alcohol abuse
 |===
 
 === Application schema Safety

--- a/data/pf/dataspecification_pf.adoc
+++ b/data/pf/dataspecification_pf.adoc
@@ -1663,7 +1663,7 @@ a|
 !Name: !Installation Part Type
 !Definition: !Coded values describing the typology of the Installation Part
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/InstallationPartType
+!Identifier: !http://inspire.ec.europa.eu/codelist/InstallationPartType
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -1680,7 +1680,7 @@ a|
 !Name: !Installation Type
 !Definition: !Coded values describing the typology of the Installation
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/InstallationType
+!Identifier: !http://inspire.ec.europa.eu/codelist/InstallationType
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -1697,7 +1697,7 @@ a|
 !Name: !pollution abatement technique value
 !Definition: !The PollutionAbatementTechniqueValue code list hosts the reference values for the attribute technique in the ProductionInstallationPart class.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/PollutionAbatementTechniqueValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/PollutionAbatementTechniqueValue
 !Values: !The allowed values for this code list comprise the values specified in _Annex C_ and additional values at any level defined by data providers.
 !===
 
@@ -1714,7 +1714,7 @@ a|
 !Name: !River Basin District
 !Definition: !Code identifiers and/or names assigned to river basin districts.The allowed values for this code list comprise any values defined by data providers.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/RiverBasinDistrictValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/RiverBasinDistrictValue
 !Values: !The allowed values for this code list comprise any values defined by data providers.
 !===
 
@@ -2521,7 +2521,7 @@ a|
 !===
 !Name: !destination value
 !Definition: !The DestinationValue enumeration hosts the reference values for the attribute destination in the Emission class.
-!URI: !http://inspire.ec.europa.eu/codeList/DestinationValue
+!URI: !http://inspire.ec.europa.eu/codelist/DestinationValue
 !===
 
 |===
@@ -2536,7 +2536,7 @@ a|
 !===
 !Name: !flow appearance value
 !Definition: !The FlowAppearanceValue enumeration hosts the reference values for the attribute flowAppearance in the Emission class.
-!URI: !http://inspire.ec.europa.eu/codeList/ FlowAppearanceValue
+!URI: !http://inspire.ec.europa.eu/codelist/ FlowAppearanceValue
 !===
 
 a|
@@ -2567,7 +2567,7 @@ a|
 !===
 !Name: !registration nature value
 !Definition: !The RegistrationNatureValue enumeration hosts the reference values for the attribute registrationNature in the Emission class.
-!URI: !http://inspire.ec.europa.eu/codeList/ RegistrationNatureValue
+!URI: !http://inspire.ec.europa.eu/codelist/ RegistrationNatureValue
 !===
 
 a|
@@ -2627,7 +2627,7 @@ a|
 !Definition: !The CLPCodeValue code list hosts the family of reference values for the "substance" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes and to the attribute pollutantSubstance in the Emission class. Substance means any chemical element and its compounds, with the exception of some specific substances.
 !Description: !The exception deals with the following substances: radioactive substances as defined in Article 1 of Council Directive 96/29/Euratom of 13 May 1996 laying down basic safety standards for the protection of the health of workers and the general public against the dangers arising from ionising radiation(2); genetically modified micro-organisms as defined in Article 2(b) of Directive 2009/41/EC of the European Parliament and the Council of 6 May 2009 on the contained use of genetically modified micro-organisms; genetically modified organisms as defined in point 2 of Article 2 of Directive 2001/18/EC of the European Parliament and of the Council of 12 March 2001 on the deliberate release into the environment of genetically modified organisms.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/CLPCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CLPCodeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers. _Annex C_ includes recommended values that may be used by data providers.
 !===
 
@@ -2645,7 +2645,7 @@ a|
 !Definition: !The CPACodeValue code list hosts the family of reference values for the "product" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. A product means something that is produced, result of manufacturing, a result of an action or a process.
 !Description: !CPA is the Standard Classification of Economic Products from Annex Regulation (EC) n. 451/2008. It has a hierarchical structure funded on different levels embedded in the activity code referring to the product. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/CPACodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CPACodeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers. _Annex C_ includes recommended values that may be used by data providers.
 !===
 
@@ -2663,7 +2663,7 @@ a|
 !Definition: !The E-PRTRCodeValue code list hosts a family of reference values for the attribute activityCode in the Activity class. The list hosts the classification for the activities according to the E-PRTR register.
 !Description: !E-PRTR classification has a hierarchical structure funded on different levels embedded in the activity code. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/E-PRTRCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/E-PRTRCodeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers. _Annex C_ includes recommended values that may be used by data providers.
 !===
 
@@ -2681,7 +2681,7 @@ a|
 !Definition: !The EnergyClassificationValue code list hosts the family of reference values for the "energy" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. Energy means power derived from physical or chemical resources able to provide light and heat to work machines.
 !Description: !The present classification has been derived from the Country factsheets which provide an overview of the most recent and pertinent annual energy related statistics in Europe, covering the European Union with its Member States. The content of this collection is based on a range of sources, including EUROSTAT, DG ECFIN, and EEA.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/EnergyClassificationValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EnergyClassificationValue
 !Values: !The allowed values for this code list comprise the values specified in _Annex C_ and additional values at any level defined by data providers.
 !===
 
@@ -2699,7 +2699,7 @@ a|
 !Definition: !The EWCCodeValue code list hosts the family of reference values for the "waste" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. Waste means any substance or object which the holder discards or intends or is required to discard.
 !Description: !EWC classification has a hierarchical structure funded on different levels embedded in the waste code. The waste code is accompanied by the waste denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/EWCCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EWCCodeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers. _Annex C_ includes recommended values that may be used by data providers.
 !===
 
@@ -2717,7 +2717,7 @@ a|
 !Definition: !The IPPCCodeValue code list hosts a family of reference values for the attribute activityCode in the Activity class. The list hosts the classification for the activities according to the Council Regulation 96/61/EC.
 !Description: !IPPC classification has a hierarchical structure funded on different levels embedded in the activity code. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/IPPCCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/IPPCCodeValue
 !Values: !The allowed values for this code list comprise any values defined by data providers. _Annex C_ includes recommended values that may be used by data providers.
 !===
 
@@ -2735,7 +2735,7 @@ a|
 !Definition: !The NACECodeValue code list hosts a family of reference values for the attribute activityCode in the Activity class. The list hosts the classification for the activities according to the Council Regulation 3037/90/EEC.
 !Description: !NACE classification has a hierarchical structure founded on different levels embedded in the activity code. The activity code is accompanied by the activity denomination.
 !Extensibility: !none
-!Identifier: !http://inspire.ec.europa.eu/codeList/NACECodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/NACECodeValue
 !Parent: !ClassificationItemTypeValue
 !Values: !The allowed values for this code list comprise only the values specified in "Regulation (EC) No 1893/2006 of the European Parliament and of the Council"
 !===
@@ -2920,28 +2920,28 @@ The values of selected external code lists are included in Annex C for informati
 [cols=",,",]
 |===
 |*Code list* |*Identifiers* |*Examples*
-|NACECodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/ NACECodeValue / |http://ec.europa.eu/competition/mergers/cases/index/nace_all.html
-|IPPCCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/ IPPCCodeValue/ a|
+|NACECodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/ NACECodeValue / |http://ec.europa.eu/competition/mergers/cases/index/nace_all.html
+|IPPCCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/ IPPCCodeValue/ a|
 http://nomeports.ecoports.com/ContentFiles/IPPC141.pdf
 
 _Annex V, Table I._
 
 IPPC Code
 
-|E-PRTRCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/ E-PRTRCodeValue/ a|
+|E-PRTRCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/ E-PRTRCodeValue/ a|
 
 http://www.epa.ie/downloads/advice/licensee/e_prtr_regulation_%20annex_%20i.pdf
 
 
 Annex I.
 
-|CPACodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/CPACodeValue/ |http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&StrNom=CPA_2008&StrLanguageCode=EN&IntPcKey=&StrLayoutCode=HIERARCHIC&IntCurrentPage=1
-|CLPCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/CLPCodeValue/ a|
+|CPACodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/CPACodeValue/ |http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&StrNom=CPA_2008&StrLanguageCode=EN&IntPcKey=&StrLayoutCode=HIERARCHIC&IntCurrentPage=1
+|CLPCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/CLPCodeValue/ a|
 http://www.prc.cnrs-gif.fr/reach/en/images/annex-6-abstract-en.pdf
 
 Column: Index Num.
 
-|EWCCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codeList/EWCCodeValue/ a|
+|EWCCodeValue |Append the upper-case alphanumeric "Code" to the URI prefix http://inspire.ec.europa.eu/codelist/EWCCodeValue/ a|
 http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:L:2000:226:0003:0024:EN:PDF
 
 _Chapter: INDEX_
@@ -6000,7 +6000,7 @@ a|
 !Name: !pollution abatement technique value
 !Definition: !The PollutionAbatementTechniqueValue code list hosts the reference values for the attribute technique in the ProductionInstallationPart class.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/PollutionAbatementTechniqueValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/PollutionAbatementTechniqueValue
 !Values: !The allowed values for this code list comprise the values specified in the table below and additional values at any level defined by data providers.
 !===
 
@@ -6097,7 +6097,7 @@ a|
 !Definition: !The CLPCodeValue code list hosts the family of reference values for the "substance" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes and to the attribute pollutantSubstance in the Emission class. Substance means any chemical element and its compounds, with the exception of some specific substances.
 !Description: !The exception deals with the following substances: radioactive substances as defined in Article 1 of Council Directive 96/29/Euratom of 13 May 1996 laying down basic safety standards for the protection of the health of workers and the general public against the dangers arising from ionising radiation(2); genetically modified micro-organisms as defined in Article 2(b) of Directive 2009/41/EC of the European Parliament and the Council of 6 May 2009 on the contained use of genetically modified micro-organisms; genetically modified organisms as defined in point 2 of Article 2 of Directive 2001/18/EC of the European Parliament and of the Council of 12 March 2001 on the deliberate release into the environment of genetically modified organisms.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/CLPCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CLPCodeValue
 !Values: !
 !===
 
@@ -6114,7 +6114,7 @@ a|
 !Definition: !The CPACodeValue code list hosts the family of reference values for the "product" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. A product means something that is produced, result of manufacturing, a result of an action or a process.
 !Description: !CPA is the Standard Classification of Economic Products from Annex Regulation (EC) n. 451/2008. It has a hierarchical structure funded on different levels embedded in the activity code referring to the product. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/CPACodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/CPACodeValue
 !Values: !
 !===
 
@@ -6131,7 +6131,7 @@ a|
 !Definition: !The E-PRTRCodeValue code list hosts a family of reference values for the attribute activityCode in the Activity class. The list hosts the classification for the activities according to the E-PRTR register.
 !Description: !E-PRTR classification has a hierarchical structure funded on different levels embedded in the activity code. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/E-PRTRCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/E-PRTRCodeValue
 !Values: !
 !===
 
@@ -6148,7 +6148,7 @@ a|
 !Definition: !The EWCCodeValue code list hosts the family of reference values for the "waste" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. Waste means any substance or object which the holder discards or intends or is required to discard.
 !Description: !EWC classification has a hierarchical structure funded on different levels embedded in the waste code. The waste code is accompanied by the waste denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/EWCCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EWCCodeValue
 !Values: !
 !===
 
@@ -6165,7 +6165,7 @@ a|
 !Definition: !The EnergyClassificationValue code list hosts the family of reference values for the "energy" item referred to the attribute processItem in the ProcessInput or ProcessOutput classes. Energy means power derived from physical or chemical resources able to provide light and heat to work machines.
 !Description: !The present classification has been derived from the Country factsheets which provide an overview of the most recent and pertinent annual energy related statistics in Europe, covering the European Union with its Member States. The content of this collection is based on a range of sources, including EUROSTAT, DG ECFIN, and EEA.
 !Extensibility: !open
-!Identifier: !http://inspire.ec.europa.eu/codeList/EnergyClassificationValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/EnergyClassificationValue
 !Values: !
 !===
 
@@ -6242,7 +6242,7 @@ a|
 !Definition: !The IPPCCodeValue code list hosts a family of reference values for the attribute activityCode in the Activity class. The list hosts the classification for the activities according to the Council Regulation 96/61/EC.
 !Description: !IPPC classification has a hierarchical structure funded on different levels embedded in the activity code. The activity code is accompanied by the activity denomination.
 !Extensibility: !any
-!Identifier: !http://inspire.ec.europa.eu/codeList/IPPCCodeValue
+!Identifier: !http://inspire.ec.europa.eu/codelist/IPPCCodeValue
 !Values: !
 !===
 

--- a/data/tn/dataspecification_tn.adoc
+++ b/data/tn/dataspecification_tn.adoc
@@ -945,7 +945,7 @@ The following two types of code lists are distinguished in INSPIRE:
 
 * _Code lists that are governed by INSPIRE (INSPIRE-governed code lists)._ These code lists will be managed centrally in the INSPIRE code list register. Change requests to these code lists (e.g. to add, deprecate or supersede values) are processed and decided upon using the INSPIRE code list register's maintenance workflows.
 +
-INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codeList/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codeList/<CodeListName__>/<value>.
+INSPIRE-governed code lists will be made available in the INSPIRE code list register at __http://inspire.ec.europa.eu/codelist/<CodeListName__>. They will be available in SKOS/RDF, XML and HTML. The maintenance will follow the procedures defined in ISO 19135. This means that the only allowed changes to a code list are the addition, deprecation or supersession of values, i.e. no value will ever be deleted, but only receive different statuses (valid, deprecated, superseded). Identifiers for values of INSPIRE-governed code lists are constructed using the pattern __http://inspire.ec.europa.eu/codelist/<CodeListName__>/<value>.
 
 
 * _Code lists that are governed by an organisation outside of INSPIRE (externally governed code lists)._ These code lists are managed by an organisation outside of INSPIRE, e.g. the World Meteorological Organization (WMO) or the World Health Organization (WHO). Change requests to these code lists follow the maintenance workflows defined by the maintaining organisations. Note that in some cases, no such workflows may be formally defined.
@@ -975,7 +975,7 @@ NOTE Where practicable, the INSPIRE code list register could also provide http U
 
 ===== Vocabulary
 
-For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codeList/<UpperCamelCaseName>_.
+For each code list, a tagged value called "vocabulary" is specified to define a URI identifying the values of the code list. For INSPIRE-governed code lists and externally governed code lists that do not have a persistent identifier, the URI is constructed following the pattern _http://inspire.ec.europa.eu/codelist/<UpperCamelCaseName>_.
 
 If the value is missing or empty, this indicates an empty code list. If no sub-classes are defined for this empty code list, this means that any code list may be used that meets the given definition.
 


### PR DESCRIPTION
Certain codelist identifiers contain the wrong value "codeList" instead of "codelist". This fix applies to the following TGs: AF, HB, HH, PF, and TN.